### PR TITLE
added canvas detection

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -20,6 +20,13 @@
     "use strict";
 
     /**
+     * Check canvas support
+     */
+    var elem = document.createElement('canvas');
+    if(!elem.getContext || !elem.getContext('2d'))
+       return $.fn.knob = $.noop;
+
+    /**
      * Definition of globals and core
      */
     var k = {}, // kontrol


### PR DESCRIPTION
instead of causing an error, it will silently fail and calls to `knob()` will be ignored.

even if the knob isn't working, its better to silent fail than to generate javascript errors which can prevent execution of other scripts
