### PR TITLE
"cursor" option explained better in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Behaviors :
 * readOnly : disable input and events | default=false.
 
 UI :
-* cursor : display mode "cursor" | default=gauge.
+* cursor : display mode "cursor", cursor size could be changed passing a numeric value to the option, default width is used when passing boolean value "true" | default=gauge.
 * thickness : gauge thickness.
 * lineCap : gauge stroke endings. | default=butt, round=rounded line endings
 * width : dial width.


### PR DESCRIPTION
Reading the plugin code I noticed that cursor width could be changed passing a numeric value, so I changed the readme in order to explain this useful feature.
