### PR TITLE
Fire change event when user types in a new value or uses arrow keys

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -508,6 +508,7 @@
                                 && (v = max(min(v, s.o.max), s.o.min));
 
                                 s.change(v);
+                                s.cH(v);
                                 s._draw();
 
                                 // long time keydown speed-up


### PR DESCRIPTION
Added s.cH(s.$.val()); @line: 146 so that the change event is fired when a user types in a new value for the input.

This was pursued in response to Issue #89

Added s.cH(v); @line: 511 so that the change event is fired when a user has the input focused and is using the arrow keys.
