### PR TITLE
Fixes some slight issues when using relative width/height values.

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -239,14 +239,14 @@
 
         this._carve = function() {
             if(this.relative) {
-                var w = this.relativeWidth
+                var w = Math.floor(this.relativeWidth
                             ? this.$div.parent().width()
                                 * parseInt(this.o.width) / 100
-                            : this.$div.parent().width(),
-                    h = this.relativeHeight
+                            : this.$div.parent().width()),
+                    h = Math.floor(this.relativeHeight
                             ? this.$div.parent().height()
                                 * parseInt(this.o.height) / 100
-                            : this.$div.parent().height();
+                            : this.$div.parent().height());
 
                 // apply relative
                 this.w = this.h = Math.min(w, h);


### PR DESCRIPTION
When using % values, make sure to Math.floor the value (could just truncate to an int) to avoid drawing oddities (the side of the circle bing cut off).
