### PR TITLE
Configuring the spinner size dynamically now works.

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -77,7 +77,7 @@
                 for (k in conf) {
                     s.o[k] = conf[k];
                 }
-                s.init();
+                s._carve().init();
                 s._configure()
                  ._draw();
             };
@@ -546,7 +546,7 @@
                                     + (deltaX>0 || deltaY>0 ? s.o.step : deltaX<0 || deltaY<0 ? -s.o.step : 0);
 
                             v = max(min(v, s.o.max), s.o.min);
-                            
+
                             s.val(v);
 
                             if(s.rH) {


### PR DESCRIPTION
For example:
$Knob.trigger('configure', {"width": 110, "height": 110});
