### PR TITLE
Adding ability to specify a canvas ID

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -110,6 +110,7 @@
                     fontWeight: this.$.data('font-weight') || 'bold',
                     inline : false,
                     step : this.$.data('step') || 1,
+                    knobId : this.$.data('id') || 'knob'
 
                     // Hooks
                     draw : null, // function () {}
@@ -167,7 +168,8 @@
             // adds needed DOM elements (canvas, div)
             this.$c = $(document.createElement('canvas')).attr({
                 width: this.o.width,
-                height: this.o.height
+                height: this.o.height,
+                id: this.o.knobId
             });
 
             // wraps all elements in a div


### PR DESCRIPTION
Adding ability to specify an ID for the generated canvas element. Useful if you wish to manipulate the specific knob canvas in any way (such as absolutely positioning it in my case).
