### PR TITLE
Numeric validation for the colored foreground arc

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -153,6 +153,8 @@
                 this.v = this.$.val();
                 (this.v === '') && (this.v = this.o.min);
 
+                this.v = this.v.replace(/[^0-9.\-]/g, '');
+
                 this.$.bind(
                     'change blur'
                     , function () {


### PR DESCRIPTION
It is possible for the data value to include non-numeric characters. This happens explicitly with modifications such as: http://stackoverflow.com/questions/18955708/how-to-display-units-with-jquery-knob

This modification works well for the label, but the addition of the '%' character causes the arc not to be displayed when the page is refreshed. The above fixes this and removes all non-number characters from the value before attempting to plot it.
