### PR TITLE
Fixing behavior when stopper = false and using mousewheel

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -553,7 +553,7 @@
                         ,v = s._validate(s.$.val())
                             + (deltaX>0 || deltaY>0 ? s.o.step : deltaX<0 || deltaY<0 ? -s.o.step : 0);
 
-                    v = max(min(v, s.o.max), s.o.min);
+                    v = s.$.stopper ? max(min(v, s.o.max), s.o.min) : v;
 
                     s.val(v, false);
 


### PR DESCRIPTION
This is (sadly) my first time doing a pull request, but it was a simple change so I hope I did it right.
