### PR TITLE
Keeping the jQuery chain from breaking.

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -771,7 +771,7 @@
                 d.$ = $(this);
                 d.run();
             }
-        ).parent();
+        );
     };
 
 })(jQuery);


### PR DESCRIPTION
This plugin was not returning the DOM reference itself, but the parent so if you were trying to use the DOM element and then setting the value in a different line using the same variable, it was not really going to be possible.

Example:
$cpuUtilizationCircleProgress = $('.circle-progress').knob();
$cpuUtilizationCircleProgress.val(20).trigger('change');

The second line wasn't going to do nothing since the $cpuUtilizationCircleProgress variable were getting the wrong DOM reference from jQuery-Knob in the first line.
