### PR TITLE
Add UMD declaration

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -10,7 +10,15 @@
  *
  * Thanks to vor, eskimoblood, spiffistan, FabrizioC
  */
-(function($) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
 
     /**
      * Kontrol library
@@ -788,4 +796,5 @@
         ).parent();
     };
 
-})(jQuery);
+}));
+


### PR DESCRIPTION
In order to require this plugin using Require JS or another AMD system
both this plugin and JQuery itself must be AMD-compatible. This PR adds
the Universal Module Defintion pattern from https://github.com/umdjs/umd
so it works as expected with AMD and with traditional methods of
inclusion.
