### PR TITLE
loosen jquery version dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "ignore": [],
   "dependencies": {
-    "jquery": "1.7.0"
+    "jquery": ">=1.7.0"
   },
   "devDependencies": {}
 }
+


### PR DESCRIPTION
The previous jQuery version dependency tied the plugin to version 1.7,
not 1.7.1 or higher. I'm assuming this is compatible with 2.X too, so
loosened it to >=1.7. If it's not 2.X compatible, you could tighten it
to ~1.7 for all 1.X releases after 1.7
