### PR TITLE
Update val to be min when less, max when greater.

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -670,8 +670,8 @@
         };
 
         this.init = function () {
-            if (this.v < this.o.min
-                || this.v > this.o.max) { this.v = this.o.min; }
+            if (this.v < this.o.min) {this.v = this.o.min}
+            if (this.v > this.o.max) {this.v = this.o.max}
 
             this.$.val(this.v);
             this.w2 = this.w / 2;


### PR DESCRIPTION
This was causing an issue in rendering when values were greater than max, the value would be reset to `0`, which seemed odd. It should at the very least cap it at the max. 
