### PR TITLE
added update event listener

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -541,9 +541,17 @@
                     && v != this.v
                     && this.rH
                     && this.rH(v) === false) { return; }
+                    
+                if(!this.scrubbing)
+				{
+					this.cv = this.o.stopper ? max(min(v, this.o.max), this.o.min) : v;
+					this.v = this.cv;
+				}
+				else if(triggerRelease === false)
+				{
+					this.v = this.o.stopper ? max(min(v, this.o.max), this.o.min) : v;
+				}
 
-                this.cv = this.o.stopper ? max(min(v, this.o.max), this.o.min) : v;
-                this.v = this.cv;
                 this.$.val(this.o.format(this.v));
                 this._draw();
             } else {


### PR DESCRIPTION
bound a listener for an `update` event which calls the `val` method with the second param as `false` so as not to trigger the release handler.
this is useful when we create a knob that we update periodically as well as expect the user to interact with at the same time e.g. an audio scrubber which shows the track progress which you can change as well.
