### PR TITLE
correct callback value base on steps specified

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -322,7 +322,7 @@
 
                 if (v == s.cv) return;
 
-                if (s.cH && s.cH(v) === false) return;
+                if (s.cH && s.cH(s._validate(v)) === false) return;
 
                 s.change(s._validate(v));
                 s._draw();


### PR DESCRIPTION
When initialise knob with steps, call back value is still in raw format (float numbers). Instead it should pass back the correct value base on user's specifications on steps.