### PR TITLE
new optional feature: inactive color

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -506,7 +506,7 @@
 
         this.extend = function () {
             this.o = $.extend({
-				inactiveColor: this.$.data('inactiveColor') || "none",
+                inactiveColor: this.$.data('inactiveColor') || "none",
                 bgColor: this.$.data('bgcolor') || '#EEEEEE',
                 angleOffset: this.$.data('angleoffset') || 0,
                 angleArc: this.$.data('anglearc') || 360,
@@ -765,8 +765,7 @@
             c.lineWidth = this.lineWidth;
             c.lineCap = this.lineCap;
 
-			/* draw inactive background */
-			if( this.o.inactiveColor !== "none" ) {
+            if( this.o.inactiveColor !== "none" ) {    // draw inactive background
                 c.beginPath();
                     c.strokeStyle = this.o.inactiveColor;
                     c.arc(this.xy, this.xy, this.radius, 0, 2*Math.PI, true);

--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -770,7 +770,7 @@
                     c.strokeStyle = this.o.inactiveColor;
                     c.arc(this.xy, this.xy, this.radius, 0, 2*Math.PI, true);
                 c.stroke();
-			}
+            }
 
             if (this.o.bgColor !== "none") {
                 c.beginPath();


### PR DESCRIPTION
Hey aterrien,

great lib, thanks a lot! For my project, I needed to explictly show the unavailable part of the cirlce when using the arcAngle feature. I added an option called "inactiveColor". When set, the whole circle will be drawn with the given color before the arc is drawn.

![Screenshot inactiveColor](http://i.imgur.com/mh9mpdY.png?1)

Please pull, if you like it. 

Again, thanks for your awesome lib!

cloudarts / Wojtek