### PR TITLE
Update parse function to handle string with commas

### DIFF
--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -133,10 +133,10 @@
                     },
                     parse: function (v) {
                         
-                        //if string, remove commas, so parseFloat will get the right value
-                        if (typeof v === 'string') {
-    						v = v.replace(",", "");
-    					}
+                	//if string, remove commas, so parseFloat will get the right value
+                	if (typeof v === 'string') {
+    			   v = v.replace(",", "");
+    			}
 					
                         return parseFloat(v);
                     }

--- a/js/jquery.knob.js
+++ b/js/jquery.knob.js
@@ -132,6 +132,12 @@
                         return v;
                     },
                     parse: function (v) {
+                        
+                        //if string, remove commas, so parseFloat will get the right value
+                        if (typeof v === 'string') {
+    						v = v.replace(",", "");
+    					}
+					
                         return parseFloat(v);
                     }
                 }, this.o


### PR DESCRIPTION
If you are using a format function like the example below, it formats large numbers with commas ("1,000") to have a clean, readable format.  However, the commas are not handled by the javascript parseFloat function in the way that is needed, so you end up parsing a number that does not match the original, and it will end up setting a new value on the dial which is incorrect.  This happens when you manually type a value into the textbox.  It will format the value and output, but it looks like that trigger another change event, which values the value to get validated/parsed again.   I added a check in the 'parse' function to remove commas if the value is a string.

//EXAMPLE FORMAT FUNCTION THAT ADDS COMMA FOR THOUSANDS SEPARATORS
'format': function (val) {
    var formatted = addCommasToNumber(val);  //for "1000", would return "1,000"
    return formatted;
}   
